### PR TITLE
Don't toggle fsup unnecessarily and use None for spurious wkup

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -178,20 +178,17 @@ impl<PINS: Send+Sync> usb_device::bus::UsbBus for UsbBus<PINS> {
                 // race conditions
                 regs.istr.write(|w| unsafe { w.bits(0xffff) }.wkup().clear_bit() );
 
-                self.regs.borrow(cs).cntr.modify(|_, w| w
-                    .fsusp().clear_bit());
-
                 let fnr = regs.fnr.read();
 
                 match (fnr.rxdp().bit_is_set(), fnr.rxdm().bit_is_set()) {
                     (false, false) | (false, true) => {
+                        self.regs.borrow(cs).cntr.modify(|_, w| w
+                            .fsusp().clear_bit());
                         PollResult::Resume
                     },
                     _ => {
                         // Spurious wakeup event caused by noise
-                        self.regs.borrow(cs).cntr.modify(|_, w| w
-                            .fsusp().set_bit());
-                        PollResult::Suspend
+                        PollResult::None
                     }
                 }
             } else if istr.reset().bit_is_set() {


### PR DESCRIPTION
For some reason, the fsup toggling was resulting in the `LP` interrupt firing constantly and preventing the execution of anything else.

This also makes the spurious wakeup result a bit more correct with the `None` variant.