### PR TITLE
Add support for STM32L0x2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ cortex-m = "0.6.0"
 stm32f0xx-hal = { version = "0.14", features = ["rt"], optional = true }
 stm32f1xx-hal = { version = "0.3", features = ["rt"], optional = true }
 stm32f3xx-hal = { version = "0.2", features = ["rt"], optional = true }
+stm32l0xx-hal = { version = "0.2", features = ["rt"], optional = true }
 stm32l4xx-hal = { version = "0.4", features = ["rt"], optional = true }
 usb-device = "0.2.0"
 
@@ -23,6 +24,7 @@ usb-device = "0.2.0"
 stm32f0 = ['stm32f0xx-hal', 'delay_workaround']
 stm32f1 = ['stm32f1xx-hal']
 stm32f3 = ['stm32f3xx-hal']
+stm32l0 = ['stm32l0xx-hal', 'delay_workaround']
 stm32l4 = ['stm32l4xx-hal']
 
 # Dedicated USB RAM size
@@ -49,6 +51,7 @@ stm32f072xx = ['stm32f0', 'stm32f0xx-hal/stm32f072', 'new_gen']
 stm32f078xx = ['stm32f0', 'stm32f0xx-hal/stm32f078', 'new_gen']
 stm32f103xx = ['stm32f1', 'stm32f1xx-hal/stm32f103', 'old_gen']
 stm32f303xc = ['stm32f3', 'stm32f3xx-hal/stm32f303', 'old_gen']
+stm32l0x2xx = ['stm32l0', 'stm32l0xx-hal/stm32l0x2', 'new_gen']
 stm32l4x2xx = ['stm32l4', 'stm32l4xx-hal/stm32l4x2', 'new_gen', 'ram_addr_40006c00']
 
 # Auxiliary features

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -8,4 +8,5 @@ cargo check --no-default-features --features stm32f042xx
 #cargo check --no-default-features --features stm32f078xx
 cargo check --no-default-features --features stm32f103xx
 cargo check --no-default-features --features stm32f303xc
+cargo check --no-default-features --features stm32l0x2xx
 cargo check --no-default-features --features stm32l4x2xx

--- a/src/target.rs
+++ b/src/target.rs
@@ -7,6 +7,8 @@ pub use stm32f0xx_hal as hal;
 pub use stm32f1xx_hal as hal;
 #[cfg(feature = "stm32f3")]
 pub use stm32f3xx_hal as hal;
+#[cfg(feature = "stm32l0")]
+pub use stm32l0xx_hal as hal;
 #[cfg(feature = "stm32l4")]
 pub use stm32l4xx_hal as hal;
 
@@ -17,6 +19,8 @@ pub use hal::stm32::USB;
 #[cfg(feature = "stm32f1")]
 pub use hal::stm32::USB;
 #[cfg(feature = "stm32f3")]
+pub use hal::stm32::USB;
+#[cfg(feature = "stm32l0")]
 pub use hal::stm32::USB;
 #[cfg(feature = "stm32l4")]
 pub use hal::stm32::USB;
@@ -53,7 +57,7 @@ pub fn apb_usb_enable() {
     cortex_m::interrupt::free(|_| {
         let rcc = unsafe { (&*hal::stm32::RCC::ptr()) };
         match () {
-            #[cfg(any(feature = "stm32f0", feature = "stm32f1", feature = "stm32f3"))]
+            #[cfg(any(feature = "stm32f0", feature = "stm32f1", feature = "stm32f3", feature = "stm32l0"))]
             () => rcc.apb1enr.modify(|_, w| w.usben().set_bit()),
             #[cfg(feature = "stm32l4")]
             () => rcc.apb1enr1.modify(|_, w| w.usbfsen().set_bit()),
@@ -131,6 +135,15 @@ pub mod usb_pins {
     use super::hal::gpio::gpioa::{PA11, PA12};
 
     pub type UsbPinsType = (PA11<AF14>, PA12<AF14>);
+    impl super::UsbPins for UsbPinsType {}
+}
+
+#[cfg(feature = "stm32l0")]
+pub mod usb_pins {
+    use super::hal::gpio::{Input, Floating};
+    use super::hal::gpio::gpioa::{PA11, PA12};
+
+    pub type UsbPinsType = (PA11<Input<Floating>>, PA12<Input<Floating>>);
     impl super::UsbPins for UsbPinsType {}
 }
 


### PR DESCRIPTION
This was quite straight-forward, as far as `stm32-usbd` is concerned, although the platform-specific initialization caused me a bit of headache. None the less, I have a working example here: https://github.com/braun-embedded/rust-catena-4610/pull/3

cc @lthiery