### PR TITLE
 Require one of the device family features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ usb-device = "0.2.0"
 
 [features]
 # Device family
-stm32f0 = ['stm32f0xx-hal']
-stm32f1 = ['stm32f1xx-hal']
-stm32f3 = ['stm32f3xx-hal']
-stm32l0 = ['stm32l0xx-hal']
-stm32l4 = ['stm32l4xx-hal']
+stm32f0 = ['stm32f0xx-hal', 'family-selected']
+stm32f1 = ['stm32f1xx-hal', 'family-selected']
+stm32f3 = ['stm32f3xx-hal', 'family-selected']
+stm32l0 = ['stm32l0xx-hal', 'family-selected']
+stm32l4 = ['stm32l4xx-hal', 'family-selected']
 
 # Dedicated USB RAM size
 ram_size_512 = []
@@ -57,6 +57,7 @@ stm32l4x2xx = ['stm32l4', 'stm32l4xx-hal/stm32l4x2', 'new_gen', 'ram_addr_40006c
 # Auxiliary features
 old_gen = ['ram_size_512', 'ram_access_1x16']
 new_gen = ['ram_size_1024', 'ram_access_2x16', 'lpm_support', 'bcd_support', 'dp_pull_up_support']
+family-selected = []
 
 [package.metadata.docs.rs]
 features = ["stm32f103xx"]

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -1,3 +1,5 @@
+//! USB peripheral driver.
+
 use core::marker::PhantomData;
 use core::mem;
 use usb_device::{Result, UsbDirection, UsbError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,15 +5,27 @@
 
 #![no_std]
 
+#[cfg(not(feature = "family-selected"))]
+compile_error!("This crate requires one of the device family features enabled.
+Check Cargo.toml for supported families ('Device family' section)");
+
+#[cfg(feature = "family-selected")]
 mod endpoint;
+
+#[cfg(feature = "family-selected")]
 mod endpoint_memory;
 
+#[cfg(feature = "family-selected")]
 mod target;
 
+#[cfg(feature = "family-selected")]
 pub mod bus;
 
+#[cfg(feature = "family-selected")]
 pub use crate::bus::UsbBus;
+#[cfg(feature = "family-selected")]
 pub use crate::target::usb_pins::UsbPinsType;
+#[cfg(feature = "family-selected")]
 pub type UsbBusType = UsbBus<UsbPinsType>;
 
 mod pac;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@ mod endpoint_memory;
 
 mod target;
 
-/// USB peripheral driver.
 pub mod bus;
 
 pub use crate::bus::UsbBus;


### PR DESCRIPTION
Implemented in the same way as in `stm32f4xx-hal`.
See also: https://github.com/stm32-rs/stm32-usbd/issues/9