### PR TITLE
Fix force_reenumeration signature

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -56,7 +56,7 @@ impl<PINS: UsbPins+Sync> UsbBus<PINS> {
     /// This function will be called with USB peripheral powered down
     /// and interrupts disabled.
     /// It should perform disconnect in a platform-specific way.
-    pub fn force_reenumeration<F: FnOnce()>(&mut self, disconnect: F)
+    pub fn force_reenumeration<F: FnOnce()>(&self, disconnect: F)
     {
         interrupt::free(|cs| {
             let regs = self.regs.borrow(cs);


### PR DESCRIPTION
so it can be called via UsbDevice::bus()

See also: https://github.com/stm32-rs/stm32-usbd/pull/8