### PR TITLE
Updated wakeup logic to check for spurious wakeups

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -187,10 +187,17 @@ impl<USB: UsbPeripheral> usb_device::bus::UsbBus for UsbBus<USB> {
                 // race conditions
                 regs.istr.write(|w| unsafe { w.bits(0xffff) }.wkup().clear_bit());
 
-                // Required by datasheet
-                regs.cntr.modify(|_, w| w.fsusp().clear_bit());
-
-                PollResult::Resume
+                // we need to check and see the reason for the wakeup  
+                if regs.fnr.read().rxdp().bit() {
+                    // spurious wakeup. We go back to sleep
+                    PollResult::Suspend
+                } else {
+                    // real wakeup
+                    
+                    // Required by datasheet
+                    regs.cntr.modify(|_, w| w.fsusp().clear_bit());
+                    PollResult::Resume
+                }
             } else if istr.reset().bit_is_set() {
                 regs.istr.write(|w| unsafe { w.bits(0xffff) }.reset().clear_bit());
 


### PR DESCRIPTION
Hi all,  

Thanks for all of the great work on this project, I am trying to teach myself Rust by working on a small embedded project, and the work here is super helpful. 

I am currently working on getting the USB suspend/resume logic to work properly in my device, and I think I found a bug in the current code. 

Currently, at least with the 32L0358DISCOVERY Devkit, starting the
stack with the USB port unplugged, or removing the USB port results in
the USB stack being left in state UsbDeviceState::Default. The
expected behavior is that the USB stack stays in the suspended state.

This causes the resume() functions to be called in the HAL, which
means it is not possible to leave the USB hardware in the low power
state.

According to ST document RM0267, section 32.5.5, it is possible to get
spurious wakeup events on the USB bus, even if the bus is still
suspended. Table 159 describes the proper response:

|(RXDP,RXDM)| Wakeup Event        | Required Action         |
|-----------|---------------------|-------------------------|
|  (0,0)    | Root Reset          | None                    |
|  (0,1)    | None (noise on bus) | Go Back in Suspend Mode |
|  (1,0)    | Root Resume         | None                    |
|  (1,1)    | N/A (Noise on bus)  | Go Back in Suspend Mode |

In summary, the status of these bits needs to be checked to make sure
that the source of the wakeup is not spurious noise, and allow the
system to go back to sleep if so.

If you want to test this, I made a small app that printed out the current usb-device bus state to a serial port, and watched for changes as I reset the microcontroller and plugged/unplugged the device. 

I don't have  a standalone demo program, but this repository does include that logic:

https://github.com/apgoetz/led_clock