### PR TITLE
Use 16-bit access for both 1x16 and 2x16 access types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,3 @@ ram_access_2x16 = []
 
 [package.metadata.docs.rs]
 features = ["ram_access_2x16"]
-
-[[example]]
-name = "hal"
-required-features = ["ram_access_1x16"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,3 @@ stm32f1xx-hal = { version = "0.4.0", features = ["stm32f103"] }
 # USB RAM access scheme
 ram_access_1x16 = []
 ram_access_2x16 = []
-
-[package.metadata.docs.rs]
-features = ["ram_access_2x16"]

--- a/README.md
+++ b/README.md
@@ -27,10 +27,6 @@ started by [@mvirkkunen](https://github.com/mvirkkunen).
 This driver is intended for use through a device hal library.
 Such hal library should implement `UsbPeripheral` for the corresponding USB peripheral object.
 This trait declares all the peripheral properties that may vary from one device family to the other.
-Additionally, hal should pass `ram_access_1x16` of `ram_access_2x16` feature to the `stm32-usbd` library to
-define endpoint memory access scheme:
-* `ram_access_1x16` - for "1x16 bits/word" access scheme
-* `ram_access_2x16` - for "2x16 bits/word" access scheme
 
 ## Examples
 

--- a/examples/hal.rs
+++ b/examples/hal.rs
@@ -20,6 +20,7 @@ unsafe impl UsbPeripheral for Peripheral {
     const DP_PULL_UP_FEATURE: bool = false;
     const EP_MEMORY: *const () = 0x4000_6000 as _;
     const EP_MEMORY_SIZE: usize = 512;
+    const EP_MEMORY_ACCESS_2X16: bool = false;
 
     fn enable() {
         let rcc = unsafe { &*RCC::ptr() };

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -17,8 +17,8 @@ pub const NUM_ENDPOINTS: usize = 8;
 /// Arbitrates access to the endpoint-specific registers and packet buffer memory.
 #[derive(Default)]
 pub struct Endpoint<USB> {
-    out_buf: Option<Mutex<EndpointBuffer>>,
-    in_buf: Option<Mutex<EndpointBuffer>>,
+    out_buf: Option<Mutex<EndpointBuffer<USB>>>,
+    in_buf: Option<Mutex<EndpointBuffer<USB>>>,
     ep_type: Option<EndpointType>,
     index: u8,
     _marker: PhantomData<USB>,
@@ -67,8 +67,8 @@ impl<USB: UsbPeripheral> Endpoint<USB> {
         self.out_buf.is_some()
     }
 
-    pub fn set_out_buf(&mut self, buffer: EndpointBuffer, size_bits: u16) {
-        let offset = buffer.offset::<USB>();
+    pub fn set_out_buf(&mut self, buffer: EndpointBuffer<USB>, size_bits: u16) {
+        let offset = buffer.offset();
         self.out_buf = Some(Mutex::new(buffer));
 
         let descr = self.descr();
@@ -80,8 +80,8 @@ impl<USB: UsbPeripheral> Endpoint<USB> {
         self.in_buf.is_some()
     }
 
-    pub fn set_in_buf(&mut self, buffer: EndpointBuffer) {
-        let offset = buffer.offset::<USB>();
+    pub fn set_in_buf(&mut self, buffer: EndpointBuffer<USB>) {
+        let offset = buffer.offset();
         self.in_buf = Some(Mutex::new(buffer));
 
         let descr = self.descr();

--- a/src/endpoint_memory.rs
+++ b/src/endpoint_memory.rs
@@ -5,10 +5,9 @@ use core::slice;
 use usb_device::{Result, UsbError};
 use vcell::VolatileCell;
 
-
 pub struct EndpointBuffer<USB> {
     mem: &'static mut [VolatileCell<u16>],
-    marker: PhantomData<USB>
+    marker: PhantomData<USB>,
 }
 
 impl<USB: UsbPeripheral> EndpointBuffer<USB> {
@@ -91,11 +90,7 @@ impl<USB: UsbPeripheral> EndpointBuffer<USB> {
 
     pub fn offset(&self) -> u16 {
         let buffer_address = self.mem.as_ptr() as usize;
-        let word_size = if USB::EP_MEMORY_ACCESS_2X16 {
-            2
-        } else {
-            4
-        };
+        let word_size = if USB::EP_MEMORY_ACCESS_2X16 { 2 } else { 4 };
         let index = (buffer_address - USB::EP_MEMORY as usize) / word_size;
         (index << 1) as u16
     }
@@ -119,11 +114,7 @@ pub struct BufferDescriptor<USB> {
 impl<USB: UsbPeripheral> BufferDescriptor<USB> {
     #[inline(always)]
     fn field(&self, index: usize) -> &'static VolatileCell<u16> {
-        let mul = if USB::EP_MEMORY_ACCESS_2X16 {
-            1
-        } else {
-            2
-        };
+        let mul = if USB::EP_MEMORY_ACCESS_2X16 { 1 } else { 2 };
         unsafe { &*(self.ptr.add(index * mul)) }
     }
 
@@ -176,17 +167,13 @@ impl<USB: UsbPeripheral> EndpointMemoryAllocator<USB> {
     }
 
     pub fn buffer_descriptor(index: u8) -> BufferDescriptor<USB> {
-        let mul = if USB::EP_MEMORY_ACCESS_2X16 {
-            1
-        } else {
-            2
-        };
+        let mul = if USB::EP_MEMORY_ACCESS_2X16 { 1 } else { 2 };
 
         unsafe {
             let ptr = (USB::EP_MEMORY as *const VolatileCell<u16>).add((index as usize) * 4 * mul);
             BufferDescriptor {
                 ptr,
-                marker: Default::default()
+                marker: Default::default(),
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,13 @@ pub unsafe trait UsbPeripheral: Send + Sync {
     /// Endpoint memory size in bytes
     const EP_MEMORY_SIZE: usize;
 
+    #[cfg(not(any(feature = "ram_access_1x16", feature = "ram_access_2x16")))]
+    const EP_MEMORY_ACCESS_2X16: bool;
+    #[cfg(feature = "ram_access_1x16")]
+    const EP_MEMORY_ACCESS_2X16: bool = false;
+    #[cfg(feature = "ram_access_2x16")]
+    const EP_MEMORY_ACCESS_2X16: bool = true;
+
     /// Enables USB device on its peripheral bus
     fn enable();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,10 @@ pub unsafe trait UsbPeripheral: Send + Sync {
     const EP_MEMORY_SIZE: usize;
 
     #[cfg(not(any(feature = "ram_access_1x16", feature = "ram_access_2x16")))]
+    /// Endpoint memory access scheme
+    ///
+    /// Check Reference Manual for details.
+    /// Set to `true` if "2x16 bits/word" access scheme is used, otherwise set to `false`.
     const EP_MEMORY_ACCESS_2X16: bool;
     #[cfg(feature = "ram_access_1x16")]
     const EP_MEMORY_ACCESS_2X16: bool = false;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@
 
 #![no_std]
 
-#[cfg(not(any(feature = "ram_access_1x16", feature = "ram_access_2x16")))]
-compile_error!("This crate requires one of the ram_access features enabled");
 #[cfg(all(feature = "ram_access_1x16", feature = "ram_access_2x16"))]
 compile_error!("Multiple ram_access features are specified. Only a single feature can be specified.");
 


### PR DESCRIPTION
Experiment showed that it's not necessary to use 32-bit access on a chip with 1x16 access type (like STM32F103), 16-bit accesses work just fine. Getting rid of different types for endpoint memory access allows replacing `ram_access_*` features with an associated constant in the `UsbPeripheral` trait. This should allow better handling of this option on STM32F3xx family where both access types are used.