### PR TITLE
Update Deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["no-std", "embedded", "usb"]
 
 [dependencies]
 vcell = "0.1.2"
-cortex-m = "0.6.1"
+cortex-m = "0.7.1"
 usb-device = "0.2.3"
 
 [dev-dependencies]


### PR DESCRIPTION
The first commit updates `cortex-m`. `cortex-m` v0.6.5+ [are forward-compatible](https://github.com/rust-embedded/cortex-m/blob/master/CHANGELOG.md#v065---2021-01-24) with `cortex-m` v0.7.0+, so this should be fine as a point release.