### PR TITLE
Update to usb-device 0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["no-std", "embedded", "usb"]
 [dependencies]
 vcell = "0.1.2"
 cortex-m = "0.7.1"
-usb-device = "0.2.3"
+usb-device = "0.3.1"
 
 [dev-dependencies]
 stm32f1xx-hal = { version = "0.7.0", features = ["stm32f103"] }

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -237,7 +237,8 @@ trait EndpointTypeExt {
 impl EndpointTypeExt for EndpointType {
     fn bits(self) -> u8 {
         const BITS: [u8; 4] = [0b01, 0b10, 0b00, 0b11];
-        return BITS[self as usize];
+        let transfer_type = self.to_bm_attributes() & 0b11;
+        return BITS[transfer_type as usize];
     }
 }
 


### PR DESCRIPTION
Update to a recently released usb-device 0.3.1

Fix the build issue with EndpointType changes - it's no longer can be converted to usize, instead there's a new function to_bm_attributes(), which returns Transfer Type and additional Iso Mode flags.

This change is not tested on a real hardware.