### PR TITLE
Remove stm32-usbd-examples from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ This trait declares all the peripheral properties that may vary from one device 
 
 ## Examples
 
-See the [stm32-usbd-examples](https://github.com/stm32-rs/stm32-usbd-examples) repo for different device-specific examples.
+Example applications may be found in the individual device HALs:
 
-See the `hal` example for the reference hal implementation.
+- [stm32f0xx-hal USB Serial](https://github.com/stm32-rs/stm32f0xx-hal/blob/master/examples/usb_serial.rs)
+- [stm32f1xx-hal USB Serial](https://github.com/stm32-rs/stm32f1xx-hal/blob/master/examples/usb_serial.rs)
+- [stm32f3xx-hal USB Serial](https://github.com/stm32-rs/stm32f3xx-hal/blob/master/examples/usb_serial.rs)
+- [stm32l0xx-hal USB Serial](https://github.com/stm32-rs/stm32l0xx-hal/blob/master/examples/usb_serial.rs)
+- [stm32l4xx-hal USB Serial](https://github.com/stm32-rs/stm32l4xx-hal/blob/master/examples/usb_serial.rs)


### PR DESCRIPTION
See https://github.com/stm32-rs/stm32-usbd-examples/issues/13

This messed me up trying to get up and running with `stm32-usbd` - the examples in the linked `stm32-usbd-examples` repo are out of date, and the working examples are in the individual HAL crates.

I don't know if it's good practice to link to specific example files like this, but they seem consistent and stable so maybe it's fine.