### PR TITLE
Release v0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stm32-usbd"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2018"
 authors = ["Matti Virkkunen <mvirkkunen@gmail.com>", "Vadim Kaushan <admin@disasm.info>", "Nicolas Stalder <n@stalder.io>", "Jonas Martin <lichtfeind@gmail.com>"]
 description = "'usb-device' implementation for STM32 microcontrollers"


### PR DESCRIPTION
This release is created for convenience, so that other people can start porting and testing other libraries.
Note that no testing for the release was performed apart from a few reports in https://github.com/stm32-rs/stm32-usbd/issues/35. Use at your own risk!

Closes https://github.com/stm32-rs/stm32-usbd/issues/35