### PR TITLE
Release v0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stm32-usbd"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2018"
 authors = ["Matti Virkkunen <mvirkkunen@gmail.com>", "Vadim Kaushan <admin@disasm.info>", "Nicolas Stalder <n@stalder.io>", "Jonas Martin <lichtfeind@gmail.com>"]
 description = "'usb-device' implementation for STM32 microcontrollers"


### PR DESCRIPTION
Tested on BluePill (STM32F103C8),  STM32F3DISCOVERY (STM32F303VC), NUCLEO-F042K6 (STM32F042K6).
usb-device 0.3.2, usbd-serial 0.2.2
* disconnect (interrupt) test passed
* serial test passed
* test_class test passed
* USB compliance test failed, but all the problems are related to `usb-device` implementation.

Failed tests in Chapter 9 test suite:
* 9.4 Interface Descriptor Test - SetInterface failed for an interface with two alt settings (not implemented in usb-device)
* 9.9 Halt Endpoint Test - SetInterface failed for an interface with two alt settings
* 9.21 LPM L1 Suspend Resume Test - bit is not set in BOS descriptor

None of these are related to the functionality of the driver, so I can assume that no new problems were introduced.

Also I tried to test on NUCLEO-L432KC. I didn't manage to make examples work (apparently there were clock configuration issues) and then I damaged the device.